### PR TITLE
Standard as 1.0.0, working draft as 1.1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,14 +47,22 @@
     </ul>
 
     <a name="spec"></a>
-    <h2>Specification</h2>
+    <h2>Current Specification</h2>
     
     <ul>
         <li>
-            <a class="version" href="html/owin.html">OWIN v1.1.0</a>
+            <a class="version" href="/spec/spec/owin-1.0.0.html">OWIN v1.0</a>
         </li>
     </ul>
     
+    <a name="drafts"></a>
+    <h2>Drafts and work in progress</h2>
+    
+    <ul>
+        <li>
+            <a class="version" href="/html/owin.html">OWIN v1.1.0</a>
+        </li>
+    </ul>
     <h2>Extensions</h2>
 
     <ul id="extendlist">


### PR DESCRIPTION
if it's a draft, it's not the published standard, so shouldn't be the only link on the page.
